### PR TITLE
Support for numeric keypads

### DIFF
--- a/snoopy.el
+++ b/snoopy.el
@@ -94,6 +94,16 @@
     (define-key map (kbd "*") (snoopy-insert-char ?8))
     (define-key key-translation-map (kbd "(") 'snoopy-insert-special)
     (define-key key-translation-map (kbd ")") 'snoopy-insert-special)
+    (define-key map (kbd "<kp-1>") (snoopy-insert-char ?1))
+    (define-key map (kbd "<kp-2>") (snoopy-insert-char ?2))
+    (define-key map (kbd "<kp-3>") (snoopy-insert-char ?3))
+    (define-key map (kbd "<kp-4>") (snoopy-insert-char ?4))
+    (define-key map (kbd "<kp-5>") (snoopy-insert-char ?5))
+    (define-key map (kbd "<kp-6>") (snoopy-insert-char ?6))
+    (define-key map (kbd "<kp-7>") (snoopy-insert-char ?7))
+    (define-key map (kbd "<kp-8>") (snoopy-insert-char ?8))
+    (define-key map (kbd "<kp-9>") (snoopy-insert-char ?9))
+    (define-key map (kbd "<kp-0>") (snoopy-insert-char ?0))
     map))
 
 (defvar snoopy-lighter " Snoopy"


### PR DESCRIPTION
This patch will allow for numeric keypads to input numbers. There are a few caveats:

1. Your keyboard needs to be correctly configured to send <kp-?> for keypad entries. I have noticed that this worked fine on X-windows but not on Linux standard consoles.
2. I did not test this with paredit